### PR TITLE
Revert "Add support for binary tuple data in replication messages"

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -56,7 +56,6 @@ const TUPLE_OLD_TAG: u8 = b'O';
 const TUPLE_DATA_NULL_TAG: u8 = b'n';
 const TUPLE_DATA_TOAST_TAG: u8 = b'u';
 const TUPLE_DATA_TEXT_TAG: u8 = b't';
-const TUPLE_DATA_BINARY_TAG: u8 = b'b';
 
 // replica identity tags
 const REPLICA_IDENTITY_DEFAULT_TAG: u8 = b'd';
@@ -1256,8 +1255,6 @@ pub enum TupleData {
     UnchangedToast,
     /// Column data as text formatted value.
     Text(Bytes),
-    /// Column data.
-    Binary(Bytes),
 }
 
 impl TupleData {
@@ -1272,12 +1269,6 @@ impl TupleData {
                 let mut data = vec![0; len as usize];
                 buf.read_exact(&mut data)?;
                 TupleData::Text(data.into())
-            }
-            TUPLE_DATA_BINARY_TAG => {
-                let len = buf.read_i32::<BigEndian>()?;
-                let mut data = vec![0; len as usize];
-                buf.read_exact(&mut data)?;
-                TupleData::Binary(data.into())
             }
             tag => {
                 return Err(io::Error::new(


### PR DESCRIPTION
This reverts commit 1a494558c49d2c5a64d6051b48370ef7439f6e30.